### PR TITLE
Add event links for TPAC 2023

### DIFF
--- a/Meetings/TPAC2023/README.md
+++ b/Meetings/TPAC2023/README.md
@@ -10,6 +10,7 @@ Our slots:
 
 ### Slot 1
 Time: Thursday 11:30-13:00
+Event link: https://www.w3.org/events/meetings/8f45241f-43d7-4e26-8ec5-bf3de676d7e9/
 
 - 11:30 - 11:45 Introductions of Participants
 - 11:45 - 12:15 Explaining Web of Things
@@ -18,6 +19,7 @@ Time: Thursday 11:30-13:00
 
 ### Slot 2
 Time: Friday 11:30-13:00
+Event link: https://www.w3.org/events/meetings/b9a57d94-1dd0-44dd-aa7e-90b510b4f98a/
 
 - 11:30 - 11:45 Introductions of Participants
 - 11:45 - 12:00 Short Introduction to Web of Things
@@ -29,5 +31,6 @@ Time: Friday 11:30-13:00
   
 ### Slot 3
 Time: Friday 17:00-18:30
+Event link: https://www.w3.org/events/meetings/d77ce7ba-9167-42ee-8f47-58ee070efea0/
 
 - 17:00 - 18:30 Alternative slot for WoT WG Discussion (requires confirmation from WoT WG)


### PR DESCRIPTION
Quickly copying event links from the W3C Calendar. 